### PR TITLE
Bump 3.34.2 release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/org.gnome.Notes.json
+++ b/org.gnome.Notes.json
@@ -42,8 +42,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/gnome-online-accounts/3.34/gnome-online-accounts-3.34.0.tar.xz",
-                    "sha256" : "c44fbce4eeb54703a2ab4954d54f11eb29666f9cf61b5275b9fe0fc033377f57"
+                    "url" : "https://download.gnome.org/sources/gnome-online-accounts/3.34/gnome-online-accounts-3.34.1.tar.xz",
+                    "sha256" : "4832ca8e48d3a497fc676e7b6f146009ab4206995362977b9805aa39f164783a"
                 }
             ]
         },
@@ -106,8 +106,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/evolution-data-server/3.34/evolution-data-server-3.34.0.tar.xz",
-                    "sha256" : "fb9db0a824ae01ecc63c82cf8e503fecdcba7118b919f04bda7d8d91f3e486cf"
+                    "url" : "https://download.gnome.org/sources/evolution-data-server/3.34/evolution-data-server-3.34.3.tar.xz",
+                    "sha256" : "d2dfac5ca76e05e872fbb06a57cae0dace64818c4dce1e906b0396888270c3a9"
                 }
             ]
         },
@@ -133,8 +133,8 @@
             "sources" : [
                 {
                    "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/tracker/2.3/tracker-2.3.0.tar.xz",
-                    "sha256" : "2c04534da83419b0bc65216e367da51a420f52bb8449f4cc4542c651e5c6bf7b"
+                    "url" : "https://download.gnome.org/sources/tracker/2.3/tracker-2.3.1.tar.xz",
+                    "sha256" : "b6748726e465ad2f4d991560634b1fd0df8841f3d981b3b837c4162abedf08a1"
                 }
             ]
         },

--- a/org.gnome.Notes.json
+++ b/org.gnome.Notes.json
@@ -70,6 +70,17 @@
             ]
         },
         {
+            "name": "intltool",
+            "cleanup": [ "*" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz",
+                    "sha256": "67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd"
+                }
+            ]
+        },
+        {
             "name" : "evolution-data-server",
             "cleanup" : [
                 "/lib/cmake",
@@ -98,9 +109,6 @@
                     "url" : "https://download.gnome.org/sources/evolution-data-server/3.34/evolution-data-server-3.34.0.tar.xz",
                     "sha256" : "fb9db0a824ae01ecc63c82cf8e503fecdcba7118b919f04bda7d8d91f3e486cf"
                 }
-            ],
-            "modules": [
-                "shared-modules/intltool/intltool-0.51.json"
             ]
         },
         {

--- a/org.gnome.Notes.json
+++ b/org.gnome.Notes.json
@@ -147,8 +147,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/bijiben/3.34/bijiben-3.34.0.tar.xz",
-                    "sha256" : "34d8336c326b88bdc1243ad5e85358630ae03b418c0dc15cdb4093c7aed63673"
+                    "url" : "https://download.gnome.org/sources/bijiben/3.34/bijiben-3.34.2.tar.xz",
+                    "sha256" : "fbe2c4ea1336f888626e5c402ef330e668e214a93c733fcb9c62dbaade8eb04e"
                 }
             ]
         }


### PR DESCRIPTION
I try to keep this as close as possible to upstream.
That's the reason I'm removing the shared-modules submodule and using directly the intltool archive.
This change also updates a few dependencies.