### PR TITLE
Update org.gnome.Platform to 41 & drop few modules

### DIFF
--- a/org.gnome.Notes.json
+++ b/org.gnome.Notes.json
@@ -34,36 +34,6 @@
     "modules" : [
         "shared-modules/intltool/intltool-0.51.json",
         {
-            "name" : "curl",
-            "builddir" : true,
-            "buildsystem" : "cmake",
-            "sources" : [
-                {
-                    "type" : "archive",
-                    "url" : "https://curl.se/download/curl-7.76.0.tar.xz",
-                    "sha256" : "6302e2d75c59cdc6b35ce3fbe716481dd4301841bbb5fd71854653652a014fc8"
-                }
-            ]
-        },
-        {
-            "name" : "libhandy",
-            "buildsystem" : "meson",
-            "config-opts" : [
-                "-Dexamples=false",
-                "-Dglade_catalog=disabled",
-                "-Dintrospection=disabled",
-                "-Dtests=false",
-                "-Dvapi=false"
-            ],
-            "sources" : [
-                {
-                    "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/libhandy/1.2/libhandy-1.2.0.tar.xz",
-                    "sha256" : "39f590ae20910e76fe1c0607b2ebe589750f45610d6aeec5c30e2ee602a20b25"
-                }
-            ]
-        },
-        {
             "name" : "gnome-online-accounts",
             "config-opts" : [
                 "--disable-Werror",
@@ -130,32 +100,6 @@
                     "type" : "archive",
                     "url" : "https://download.gnome.org/sources/evolution-data-server/3.40/evolution-data-server-3.40.0.tar.xz",
                     "sha256" : "ed572f0cb6a2365809943449a8ccbee652681e2d9a1a7f4a54b60cbb53d87445"
-                }
-            ]
-        },
-        {
-            "name" : "tracker",
-            "buildsystem" : "meson",
-            "cleanup" : [
-                "/bin",
-                "/etc",
-                "/lib/systemd",
-                "/libexec",
-                "/share/dbus-1/services"
-            ],
-            "config-opts" : [
-                "--default-library=shared",
-                "-Ddocs=false",
-                "-Dman=false",
-                "-Dbash-completion=false",
-                "-Dsystemd_user_services=false",
-                "-Dtest_utils=false"
-            ],
-            "sources" : [
-                {
-                   "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/tracker/3.1/tracker-3.1.0.tar.xz",
-                    "sha256" : "ca55eb95758747ef802af4b31fc085a8d56fb9f6d003be8fd3e91e32d2e42875"
                 }
             ]
         },

--- a/org.gnome.Notes.json
+++ b/org.gnome.Notes.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.gnome.Notes",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "40",
+    "runtime-version" : "41",
     "sdk" : "org.gnome.Sdk",
     "command" : "bijiben",
     "finish-args" : [

--- a/org.gnome.Notes.json
+++ b/org.gnome.Notes.json
@@ -44,8 +44,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/gnome-online-accounts/3.38/gnome-online-accounts-3.38.1.tar.xz",
-                    "sha256" : "e18889d67806da84d1261bfed1cf61d2baec131d2d0d0a92f83ff33d4649358e"
+                    "url" : "https://download.gnome.org/sources/gnome-online-accounts/3.40/gnome-online-accounts-3.40.0.tar.xz",
+                    "sha256" : "585c4f979f6f543b77bfdb4fb01eb18ba25c2aec5b7866c676d929616fb2c3fa"
                 }
             ]
         },
@@ -66,8 +66,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://github.com/libical/libical/releases/download/v3.0.7/libical-3.0.7.tar.gz",
-                    "sha256" : "0abe66df1ea826e57db7f281c704ede834c84139012e6c686ea7adafd4e763fc"
+                    "url" : "https://github.com/libical/libical/releases/download/v3.0.11/libical-3.0.11.tar.gz",
+                    "sha256" : "1e6c5e10c5a48f7a40c68958055f0e2759d9ab3563aca17273fe35a5df7dbbf1"
                 }
             ]
         },
@@ -98,8 +98,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/evolution-data-server/3.40/evolution-data-server-3.40.0.tar.xz",
-                    "sha256" : "ed572f0cb6a2365809943449a8ccbee652681e2d9a1a7f4a54b60cbb53d87445"
+                    "url" : "https://download.gnome.org/sources/evolution-data-server/3.40/evolution-data-server-3.40.4.tar.xz",
+                    "sha256" : "87c185f18c37270e3611981f19bd9221ac974c807462c8dce90bea08712c5800"
                 }
             ]
         },

--- a/org.gnome.Notes.json
+++ b/org.gnome.Notes.json
@@ -45,7 +45,11 @@
                 {
                     "type" : "archive",
                     "url" : "https://download.gnome.org/sources/gnome-online-accounts/3.40/gnome-online-accounts-3.40.0.tar.xz",
-                    "sha256" : "585c4f979f6f543b77bfdb4fb01eb18ba25c2aec5b7866c676d929616fb2c3fa"
+                    "sha256" : "585c4f979f6f543b77bfdb4fb01eb18ba25c2aec5b7866c676d929616fb2c3fa",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "gnome-online-accounts"
+                    }
                 }
             ]
         },
@@ -99,7 +103,42 @@
                 {
                     "type" : "archive",
                     "url" : "https://download.gnome.org/sources/evolution-data-server/3.40/evolution-data-server-3.40.4.tar.xz",
-                    "sha256" : "87c185f18c37270e3611981f19bd9221ac974c807462c8dce90bea08712c5800"
+                    "sha256" : "87c185f18c37270e3611981f19bd9221ac974c807462c8dce90bea08712c5800",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "evolution-data-server"
+                    }
+                }
+            ]
+        },
+        {
+            "name" : "tracker",
+            "buildsystem" : "meson",
+            "cleanup" : [
+                "/bin",
+                "/etc",
+                "/lib/systemd",
+                "/libexec",
+                "/share/dbus-1/services"
+            ],
+            "config-opts" : [
+                "--default-library=shared",
+                "-Ddocs=false",
+                "-Dman=false",
+                "-Dbash-completion=false",
+                "-Dsystemd_user_services=false",
+                "-Dtest_utils=false"
+            ],
+            "sources" : [
+                {
+                   "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/tracker/3.1/tracker-3.1.0.tar.xz",
+                    "sha256" : "ca55eb95758747ef802af4b31fc085a8d56fb9f6d003be8fd3e91e32d2e42875",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "tracker"
+                    }
+                    
                 }
             ]
         },
@@ -113,7 +152,11 @@
                 {
                     "type" : "archive",
                     "url" : "https://download.gnome.org/sources/bijiben/40/bijiben-40.1.tar.xz",
-                    "sha256" : "05a06fb066e9802f5f24ab67b0d2f71451866363ba3e39f9f775fd49a7587bbf"
+                    "sha256" : "05a06fb066e9802f5f24ab67b0d2f71451866363ba3e39f9f775fd49a7587bbf",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "bijiben"
+                    }
                 }
             ]
         }


### PR DESCRIPTION
Drop:

  * libhandy
  * curl
  * tracker

All this modules now is a part of new GNOME runtime.