### PR TITLE
 Change socket to fallback-x11 to fix Unsafe warning #183

### DIFF
--- a/org.gnome.Notes.json
+++ b/org.gnome.Notes.json
@@ -6,7 +6,7 @@
     "command": "bijiben",
     "finish-args": [
         "--share=ipc",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--socket=wayland",
         "--device=dri",
         "--share=network",


### PR DESCRIPTION
Using `--socket=x11` results in GNOME Software showing the app as "Unsafe. Uses a legacy windowing system." Changing this to `--socket=fallback-x11`  lets app run on Wayland, but can use X11 if Wayland not available