### PR TITLE
Update required runtime version to 43

### DIFF
--- a/org.gnome.Notes.json
+++ b/org.gnome.Notes.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Notes",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "42",
+    "runtime-version": "43",
     "sdk": "org.gnome.Sdk",
     "command": "bijiben",
     "finish-args": [


### PR DESCRIPTION
The GNOME 42 runtime is no longer supported as of March 21, 2023.